### PR TITLE
Fixade så att Winner inte resettas direkt efter avslutat spel

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -26,6 +26,7 @@
                 * 
                 */
             bool programRunning = true;
+            string winner = "Uncoded One";
             while (programRunning)
 
             {
@@ -37,7 +38,6 @@
                     +
                     "\n4. End the game");
 
-                string winner = "Uncoded One";
 
                 string menyChoice = Console.ReadLine();
                 switch (menyChoice)


### PR DESCRIPTION
Flyttade string winner = "Uncoded One" utanför meny-loopen, annars sattes den igen före man kunde välja att kolla nya vinnaren